### PR TITLE
[Requirements] Add neutron client plugin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 python-openstackclient==6.0.0
+python-neutronclient==8.2.0


### PR DESCRIPTION
It seems that `openstack network trunk` commands are not present in vanilla openstackclient, but when neutronclient is installed, the openstack client can pick up its commands.